### PR TITLE
performance tweaks

### DIFF
--- a/src/JShrink/Minifier.php
+++ b/src/JShrink/Minifier.php
@@ -222,7 +222,7 @@ class Minifier
 
                         default:
                             // check for some regex that breaks stuff
-                            if ($this->a == '/' && ($this->b == '\'' || $this->b == '"')) {
+                            if ($this->a === '/' && ($this->b === '\'' || $this->b === '"')) {
                                 $this->saveRegex();
                                 continue;
                             }
@@ -311,10 +311,10 @@ class Minifier
 
         $this->c = $this->getChar();
 
-        if ($this->c == '/') {
+        if ($this->c === '/') {
             return $this->processOneLineComments($startIndex);
 
-        } elseif ($this->c == '*') {
+        } elseif ($this->c === '*') {
             return $this->processMultiLineComments($startIndex);
         }
 
@@ -336,7 +336,7 @@ class Minifier
         $this->getNext("\n");
 
         if ($thirdCommentString == '@') {
-            $endPoint = ($this->index) - $startIndex;
+            $endPoint = $this->index - $startIndex;
             unset($this->c);
             $char = "\n" . substr($this->input, $startIndex, $endPoint);
         } else {
@@ -369,8 +369,8 @@ class Minifier
             $char = $this->getChar(); // get next real character
 
             // Now we reinsert conditional comments and YUI-style licensing comments
-            if (($this->options['flaggedComments'] && $thirdCommentString == '!')
-                || ($thirdCommentString == '@') ) {
+            if (($this->options['flaggedComments'] && $thirdCommentString === '!')
+                || ($thirdCommentString === '@') ) {
 
                 // If conditional comments or flagged comments are not the first thing in the script
                 // we need to echo a and fill it with a space before moving on.
@@ -379,7 +379,7 @@ class Minifier
                     $this->a = " ";
 
                     // If the comment started on a new line we let it stay on the new line
-                    if ($this->input[($startIndex - 1)] == "\n") {
+                    if ($this->input[($startIndex - 1)] === "\n") {
                         echo "\n";
                     }
                 }
@@ -444,7 +444,7 @@ class Minifier
         $this->a = $this->b;
 
         // If this isn't a string we don't need to do anything.
-        if ($this->a != "'" && $this->a != '"') {
+        if ($this->a !== "'" && $this->a !== '"') {
             return;
         }
 
@@ -455,7 +455,7 @@ class Minifier
         echo $this->a;
 
         // Loop until the string is done
-        while (1) {
+        while (true) {
 
             // Grab the very next character and load it into a
             $this->a = $this->getChar();
@@ -485,12 +485,12 @@ class Minifier
                     $this->b = $this->getChar();
 
                     // If b is a new line we discard a and b and restart the loop.
-                    if ($this->b == "\n") {
+                    if ($this->b === "\n") {
                         break;
                     }
 
                     // echo out the escaped character and restart the loop.
-                    echo $this->a . $this->b;
+                    echo $this->a , $this->b;
                     break;
 
 
@@ -510,18 +510,18 @@ class Minifier
      */
     protected function saveRegex()
     {
-        echo $this->a . $this->b;
+        echo $this->a , $this->b;
 
         while (($this->a = $this->getChar()) !== false) {
-            if($this->a == '/')
+            if($this->a === '/')
                 break;
 
-            if ($this->a == '\\') {
+            if ($this->a === '\\') {
                 echo $this->a;
                 $this->a = $this->getChar();
             }
 
-            if($this->a == "\n")
+            if($this->a === "\n")
                 throw new \RuntimeException('Unclosed regex pattern at position: ' . $this->index);
 
             echo $this->a;
@@ -552,14 +552,14 @@ class Minifier
         $lock = '"LOCK---' . crc32(time()) . '"';
 
         $matches = array();
-        preg_match('/([+-])(\s+)([+-])/', $js, $matches);
+        preg_match('/([+-])(\s+)([+-])/S', $js, $matches);
         if (empty($matches)) {
             return $js;
         }
 
         $this->locks[$lock] = $matches[2];
 
-        $js = preg_replace('/([+-])\s+([+-])/', "$1{$lock}$2", $js);
+        $js = preg_replace('/([+-])\s+([+-])/S', "$1{$lock}$2", $js);
         /* -- */
 
         return $js;
@@ -573,7 +573,7 @@ class Minifier
      */
     protected function unlock($js)
     {
-        if (!count($this->locks)) {
+        if (empty($this->locks)) {
             return $js;
         }
 

--- a/src/JShrink/Minifier.php
+++ b/src/JShrink/Minifier.php
@@ -490,7 +490,7 @@ class Minifier
                     }
 
                     // echo out the escaped character and restart the loop.
-                    echo $this->a , $this->b;
+                    echo $this->a . $this->b;
                     break;
 
 
@@ -510,7 +510,7 @@ class Minifier
      */
     protected function saveRegex()
     {
-        echo $this->a , $this->b;
+        echo $this->a . $this->b;
 
         while (($this->a = $this->getChar()) !== false) {
             if($this->a === '/')


### PR DESCRIPTION
The incentive was that with the xdebug profiler on I ran into timeout (30s) issues, 
tried to improve it a bit. You might be interested in this, i have tested a bit, all seems fine.

* strict equality tests
* regex /S optimize flag
* omit cast to bool in while
* empty instead of counting

with xdebug on, this got me 50% faster generation (10 instead of 20s)
without xdebug its barely noticible