### PR TITLE
Don't protect newlines before opening braces

### DIFF
--- a/src/JShrink/Minifier.php
+++ b/src/JShrink/Minifier.php
@@ -181,7 +181,7 @@ class Minifier
                 // new lines
                 case "\n":
                     // if the next line is something that can't stand alone preserve the newline
-                    if (strpos('(-+{[@', $this->b) !== false) {
+                    if (strpos('(-+[@', $this->b) !== false) {
                         echo $this->a;
                         $this->saveString();
                         break;

--- a/tests/Resources/jshrink/input/remove-brace-lines.js
+++ b/tests/Resources/jshrink/input/remove-brace-lines.js
@@ -1,0 +1,7 @@
+if ( dtMonth < 1 || dtMonth > 12)
+    {
+        return false;
+    } else if ( dtDay < 1 || dtDay > 31 )
+        {
+            return false;
+        }

--- a/tests/Resources/jshrink/output/remove-brace-lines.js
+++ b/tests/Resources/jshrink/output/remove-brace-lines.js
@@ -1,0 +1,1 @@
+if(dtMonth<1||dtMonth>12){return false;}else if(dtDay<1||dtDay>31){return false;}


### PR DESCRIPTION
I had a look back through the codebase and couldn't find any explanation for why these newlines were preserved, I also couldn't find any tests to cover the feature, so this fixes #56 by stripping newlines before opening braces