### PR TITLE
Update composer to match the minimum supported version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     }
   ],
   "require": {
-    "php": "^5.3|^7.0"
+    "php": "^5.6|^7.0"
   },
   "require-dev": {
       "phpunit/phpunit": "4.0.*",


### PR DESCRIPTION
fc3546e467d573579be6d8857b101be747fb69a8 dropped support for PHP 5.2-5.5, this pr ensures `composer.json` agrees