### PR TITLE
 Fixed infinite loop when reading invalid JavaScript

### DIFF
--- a/src/JShrink/Minifier.php
+++ b/src/JShrink/Minifier.php
@@ -274,9 +274,8 @@ class Minifier
         if (isset($this->c)) {
             $char = $this->c;
             unset($this->c);
-
-            // Otherwise we start pulling from the input.
         } else {
+            // Otherwise we start pulling from the input.
             $char = substr($this->input, $this->index, 1);
 
             // If the next character doesn't exist return false.
@@ -460,7 +459,7 @@ class Minifier
 
         // Loop until the string is done
         // Grab the very next character and load it into a
-        while (($this->a = $this->getChar()) !== FALSE) {
+        while (($this->a = $this->getChar()) !== false) {
             switch ($this->a) {
 
                 // If the string opener (single or double quote) is used

--- a/src/JShrink/Minifier.php
+++ b/src/JShrink/Minifier.php
@@ -460,7 +460,7 @@ class Minifier
 
         // Loop until the string is done
         // Grab the very next character and load it into a
-        while ($this->a = $this->getChar()) {
+        while (($this->a = $this->getChar()) !== FALSE) {
             switch ($this->a) {
 
                 // If the string opener (single or double quote) is used

--- a/src/JShrink/Minifier.php
+++ b/src/JShrink/Minifier.php
@@ -459,11 +459,8 @@ class Minifier
         echo $this->a;
 
         // Loop until the string is done
-        while (true) {
-
-            // Grab the very next character and load it into a
-            $this->a = $this->getChar();
-
+        // Grab the very next character and load it into a
+        while ($this->a = $this->getChar()) {
             switch ($this->a) {
 
                 // If the string opener (single or double quote) is used


### PR DESCRIPTION
It looks like there is infinite loop while reading JavaScript code that does not have closing quote. It would be good to update the loop condition so it may correctly process input data.