### PR TITLE
Fixed test failures on PHP 7.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.idea
+/.php_cs.cache
 /.settings
 /.buildpath
 /.project

--- a/src/JShrink/Minifier.php
+++ b/src/JShrink/Minifier.php
@@ -183,7 +183,7 @@ class Minifier
                 // new lines
                 case "\n":
                     // if the next line is something that can't stand alone preserve the newline
-                    if (strpos('(-+[@', $this->b) !== false) {
+                    if ($this->b !== false && strpos('(-+[@', $this->b) !== false) {
                         echo $this->a;
                         $this->saveString();
                         break;
@@ -231,7 +231,7 @@ class Minifier
                             // check for some regex that breaks stuff
                             if ($this->a === '/' && ($this->b === '\'' || $this->b === '"')) {
                                 $this->saveRegex();
-                                continue;
+                                continue 3;
                             }
 
                             echo $this->a;


### PR DESCRIPTION
1. `continue` in `break` should target the `while` loop directly (php/php-src@04e3523).
2. `strpos()` doesn't longer accept non-string needles (https://wiki.php.net/rfc/deprecations_php_7_3#string_search_functions_with_integer_needle).

Fixes #77.