### PR TITLE
Improve performance by switching from in_array() to isset()

### DIFF
--- a/src/JShrink/Minifier.php
+++ b/src/JShrink/Minifier.php
@@ -77,7 +77,7 @@ class Minifier
     /**
      * These characters are used to define strings.
      */
-    protected $stringDelimiters = ['\'', '"', '`'];
+    protected $stringDelimiters = ['\'' => true, '"' => true, '`' => true];
 
     /**
      * Contains the default options for minification. This array is merged with
@@ -447,7 +447,7 @@ class Minifier
         $this->a = $this->b;
 
         // If this isn't a string we don't need to do anything.
-        if (!in_array($this->a, $this->stringDelimiters)) {
+        if (!isset($this->stringDelimiters[$this->a])) {
             return;
         }
 


### PR DESCRIPTION
Hi,

I've found that performance of in_array() for 3 elements is much worse than isset() and implemented the fix for saveString() method.
I've found this place in code while profiling Magento2 static content deployment procedure.
Improvement is very small, but the function called a lot of times according to xdebug profiling output (55k times in my case)

Andrey.