### PR TITLE
Update Minifier.php

### DIFF
--- a/src/JShrink/Minifier.php
+++ b/src/JShrink/Minifier.php
@@ -249,7 +249,7 @@ class Minifier
                         // no break
                         default:
                             // check for some regex that breaks stuff
-                            if ($this->a === '/' && ($this->b === '\'' || $this->b === '"')) {
+                            if ($this->a === '/' && ($this->b === '\'' || $this->b === '"'|| $this->b === '^')) {
                                 $this->saveRegex();
                                 continue 3;
                             }

--- a/src/JShrink/Minifier.php
+++ b/src/JShrink/Minifier.php
@@ -249,7 +249,7 @@ class Minifier
                         // no break
                         default:
                             // check for some regex that breaks stuff
-                            if ($this->a === '/' && ($this->b === '\'' || $this->b === '"'|| $this->b === '^')) {
+                            if ($this->a === '/' && ($this->b === '\'' || $this->b === '"' || $this->b === '^')) {
                                 $this->saveRegex();
                                 continue 3;
                             }


### PR DESCRIPTION
This quick-fix helps to identify some case, which is currently not recognized yet.

In my case i stumbled upon some problem, where the regex was not recognized as such it seems. The proposed fix helps at least for this case, where the regex has the typical start-anchor ("^").

This is the line of code where the regex was not recognized : 

return/^[a-zA-Z0-9.!#$%&\'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/.test(t)});

which is for validating email address patterns

( BTW: this code is from the formvalidation js in the Joomla 3.x series, located at /media/system/js/validate.js )