### PR TITLE
PHP 7.4 refactoring: Use strict scalar types only with automated tests.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,5 +18,8 @@ jobs:
       run: |
         composer install --no-interaction --prefer-dist
 
+    - name: PHP Unit test
+      run: ./tests/runTests.sh
+
     - name: Check PHPStan rules
       run: composer phpstan

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,22 @@
+name: Integrity check
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+    
+    - name: Install PHP
+      uses: shivammathur/setup-php@master
+      with:
+        php-version: 7.4
+
+    - name: Install composer deps
+      run: |
+        composer install --no-interaction --prefer-dist
+
+    - name: Check PHPStan rules
+      run: composer phpstan

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     }
   ],
   "require": {
-    "php": "^5.6|^7.0|^8.0"
+    "php": "^7.4|^8.0"
   },
   "require-dev": {
       "phpunit/phpunit": "^6",

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,19 @@
     "php": "^7.4|^8.0"
   },
   "require-dev": {
+      "phpstan/phpstan": "^0.12.18",
+      "phpstan/phpstan-nette": "^0.12.6",
       "phpunit/phpunit": "^6",
       "friendsofphp/php-cs-fixer": "^2.8",
       "php-coveralls/php-coveralls": "^1.1.0"
   },
   "autoload": {
     "psr-0": {"JShrink": "src/"}
-  }
+  },
+  "scripts": {
+    "phpstan": [
+      "vendor/bin/phpstan analyse src -c phpstan.neon --level 6 --no-progress"
+    ]
+  },
+  "minimum-stability": "stable"
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,3 @@
+includes:
+	- vendor/phpstan/phpstan-nette/extension.neon
+	- vendor/phpstan/phpstan-nette/rules.neon

--- a/src/JShrink/Minifier.php
+++ b/src/JShrink/Minifier.php
@@ -143,7 +143,7 @@ class Minifier
      */
     protected static function isAlphaNumeric(string $char): bool
     {
-        return $char === '/' || preg_match('/^[\w\$\pL]$/u', $char) === 1;
+        return $char === '/' || preg_match('/^[\w\$\pL]$/', $char) === 1;
     }
 
 


### PR DESCRIPTION
Hi, I refactored the whole kernel of the package to conform to PHP 7.4 standards and use strict scalar data types.

BC break: The value `false` has been replaced by the modern `null` variant.

All other changes are backward compatible. At the same time, the package was ready for future improvements such as automated tests and more.

I test all the adjustments very carefully on hundreds of examples. The whole code has been tested for the strictest PhpStan test settings and fits perfectly.

Thanks! I love this package!