### PR TITLE
Fix where "return/RegEX/" breaks minify

### DIFF
--- a/src/JShrink/Minifier.php
+++ b/src/JShrink/Minifier.php
@@ -263,7 +263,7 @@ class Minifier
             // do reg check of doom
             $this->b = $this->getReal();
 
-            if (($this->b == '/' && strpos('(,=:[!&|?', $this->a) !== false)) {
+            if (($this->b == '/' && strpos('n(,=:[!&|?', $this->a) !== false)) {
                 $this->saveRegex();
             }
         }


### PR DESCRIPTION
**tinymce.min.js** contains the following Javascript:

    return/^[^:]+:\/\/\/?[^\/]+\//.test(t)

JSShrink does not call the saveRegex method for this Javascript string as it is not a recognized RegEx starting point.

By adding "n" to the strpos test before the saveRegex call, the `return/RegEx/` situation is properly handled. In the
above case.

When it is not properly handled, the `\//.test(t)` part of the RegEx is treated as a **comment** and is
improperly truncated for **tineymce.min.js**.