### PR TITLE
Fix regex, Update Minifier.php

### DIFF
--- a/src/JShrink/Minifier.php
+++ b/src/JShrink/Minifier.php
@@ -263,7 +263,7 @@ class Minifier
             // do reg check of doom
             $this->b = $this->getReal();
 
-            if (($this->b == '/' && strpos('(,=:[!&|?', $this->a) !== false)) {
+            if (($this->b == '/' && strpos('\(,=:[!&|?', $this->a) !== false)) {
                 $this->saveRegex();
             }
         }


### PR DESCRIPTION
Fix regex line: 
example line - {"use strict";t.exports=function(t){return/^([a-z][a-z\d\+\-\.]*:)?\/\//i.test(t)}}
after processing, the code was not cut correctly
{"use strict";t.exports=function(t){return/^([a-z][a-z\d\+\-\.]*:)?\/\