### PR TITLE
Support private methods

### DIFF
--- a/src/JShrink/Minifier.php
+++ b/src/JShrink/Minifier.php
@@ -201,6 +201,7 @@ class Minifier
         '-' => true,
         '+' => true,
         '[' => true,
+        '#' => true,
         '@' => true];
 
 

--- a/tests/Resources/jshrink/input/private_methods.js
+++ b/tests/Resources/jshrink/input/private_methods.js
@@ -1,0 +1,30 @@
+export default class Example {
+  #prop
+
+  set prop (value) {
+    this.#prop = value
+
+    this.#event(value)
+  }
+  get prop () {
+    return this.#prop
+  }
+
+  constructor (arg) {
+    this.#prop = arg
+
+    if (arg) {
+      this.#method()
+    }
+  }
+
+  #event = f => {
+    if (typeof f === 'function') {
+      f()
+    }
+  }
+
+  #method = async _ => {
+    return fetch(param)
+  }
+}

--- a/tests/Resources/jshrink/output/private_methods.js
+++ b/tests/Resources/jshrink/output/private_methods.js
@@ -1,0 +1,8 @@
+export default class Example{#prop
+set prop(value){this.#prop=value
+this.#event(value)}
+get prop(){return this.#prop}
+constructor(arg){this.#prop=arg
+if(arg){this.#method()}}
+#event=f=>{if(typeof f==='function'){f()}}
+#method=async _=>{return fetch(param)}}


### PR DESCRIPTION
Private methods start with a `#` and have more limitations than normal keywords. We can avoid syntax errors by preserving a single existing newline before the `#`.


resolves #131