### PR TITLE
Fix regex detection when a character class contains unescaped forward slash

### DIFF
--- a/src/JShrink/Minifier.php
+++ b/src/JShrink/Minifier.php
@@ -628,10 +628,24 @@ class Minifier
         }
 
         $this->echo($this->b);
+        // Flag to make sure that we don't end the regex too early because of
+        // unescaped forward slashes inside a character class. e.g /[/]/
+        // In non-v-mode, The only characters that cannot appear literally are \, ], and -
+        // In v-mode more characters are reserved and forbidden from appearing literally
+        // including but not limited to [ ] \ /
+        $character_class = false;
+        $character_class_index = null;
 
         while (($this->a = $this->getChar()) !== false) {
-            if ($this->a === '/') {
+            if ($this->a === '/' && !$character_class) {
                 break;
+            }
+            
+            if ($this->a === '[') {
+                $character_class = true;
+                $character_class_index = $this->index;
+            } elseif ($this->a === ']') {
+                $character_class = false;
             }
 
             if ($this->a === '\\') {
@@ -640,6 +654,9 @@ class Minifier
             }
 
             if ($this->a === "\n") {
+                if ($character_class) {
+                    throw new \RuntimeException('Unclosed character class at position: ' . $character_class_index);
+                }
                 throw new \RuntimeException('Unclosed regex pattern at position: ' . $this->index);
             }
 

--- a/tests/JShrink/Test/JShrinkTest.php
+++ b/tests/JShrink/Test/JShrinkTest.php
@@ -32,10 +32,17 @@ class JShrinkTest extends \PHPUnit\Framework\TestCase
     public function testUnclosedRegexException()
     {
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage("Unclosed regex pattern at position: 23");
-        \JShrink\Minifier::minify('var re = /[^A-Za-z0-9_
+        $this->expectExceptionMessage("Unclosed regex pattern at position: 24");
+        \JShrink\Minifier::minify('var re = /[^A-Za-z0-9_]
         var string = "Another Filler"');
     }
+
+   public function testUnclosedCharacterClassException()
+   {
+       $this->expectException(\RuntimeException::class);
+       $this->expectExceptionMessage("Unclosed character class at position: 11");
+       \JShrink\Minifier::minify('var re = /[abc/; var string = "Another Filler"');
+   }
 
     /**
      * @jshrink

--- a/tests/Resources/jshrink/input/regex_close.js
+++ b/tests/Resources/jshrink/input/regex_close.js
@@ -4,3 +4,53 @@ function test (string) {
     '\\$1'
   )
 }
+
+// Regex with escaped slash
+function testEscapedSlash(str) {
+  var result = str.replace(/foo\/bar/, "baz");
+  return result;
+}
+
+// Regex with character class containing a slash
+function testCharClassSlash(str) {
+  var c = /[a\/b]/;
+  return c.exec(str);
+}
+
+// Regex with nested opening bracket. This is a valid regex in non-v-mode.
+function testNestedBrackets(str) {
+  try {
+    var d = /[[]/;
+    return d.test(str);
+  } catch (e) {
+    return "Error";
+  }
+}
+
+// Regex with escaped closing bracket
+function testEscapedClosingBracket(str) {
+  var e = /[a-z\]]/;
+  return e.test(str) ? "Contains letter or ]" : "No match";
+}
+
+// Regex with newlines in character class
+function testNewlineCharClass(str) {
+  var g = /[a\n:b]/;
+  return g.test(str);
+}
+
+// Regex with multiple character classes
+function testMultipleCharClasses(str) {
+  var j = /[a-z][0-9]/;
+  return j.test(str);
+}
+
+function testNestedCharacterClasses(str) {
+  // nested character class in non-v-mode. this is interpreted as /^[\[a-z]\]$/
+  return str.match(/^[[a-z]]$/);
+}
+
+function testUnclosedNestedCharacterClasses(str) {
+  // nested character class in non-v-mode. this is interpreted as /^[\[a-z]$/ and should not throw an error
+  return str.match(/^[[a-z]$/);
+}

--- a/tests/Resources/jshrink/output/regex_close.js
+++ b/tests/Resources/jshrink/output/regex_close.js
@@ -1,4 +1,9 @@
-function test(string){return(string||'').replace(/([\\!"#$%&'()*+,./:;<=>?@\[\]^`{|}~])/g,
-    '\\$1'
-  )
-}
+function test(string){return(string||'').replace(/([\\!"#$%&'()*+,./:;<=>?@\[\]^`{|}~])/g,'\\$1')}
+function testEscapedSlash(str){var result=str.replace(/foo\/bar/,"baz");return result;}
+function testCharClassSlash(str){var c=/[a\/b]/;return c.exec(str);}
+function testNestedBrackets(str){try{var d=/[[]/;return d.test(str);}catch(e){return"Error";}}
+function testEscapedClosingBracket(str){var e=/[a-z\]]/;return e.test(str)?"Contains letter or ]":"No match";}
+function testNewlineCharClass(str){var g=/[a\n:b]/;return g.test(str);}
+function testMultipleCharClasses(str){var j=/[a-z][0-9]/;return j.test(str);}
+function testNestedCharacterClasses(str){return str.match(/^[[a-z]]$/);}
+function testUnclosedNestedCharacterClasses(str){return str.match(/^[[a-z]$/);}


### PR DESCRIPTION
### Description

The current logic is failing to properly detect the following regular expression ([see](https://github.com/magento/magento2/blob/be6d0b4723c211d434f89b748b04321c97c1d4ff/lib/web/jquery/jquery.validate.js#L1072)):
```js
return string.replace( /([\\!"#$%&'()*+,./:;<=>?@\[\]^`{|}~])/g, "\\$1" );
```
resulting in
```js
.....
return this.errors().filter(selector);},escapeCssMeta:function(string){if(string===undefined){return"";}
return string.replace(/([\\!"#$%&'()*+,./:;<=>?@\[\]^`{|}~])/g, "\\$1" );
            },

            idOrName: function( element ) {
                return this.groups[ element.name ] || ( this.checkable( element ) ? element.name : element.id || element.name );
            },

            validationTargetFor: function( element ) {

                // If radio/checkbox, validate first element in group instead
                if ( this.checkable( element ) ) {
                    element = this.findByName( element.name );
                }

                // Always apply ignore filter
                return $( element ).not( this.settings.ignore )[ 0 ];
            },

            checkable: function( element ) {
                return ( /radio|checkbox/i ).test( element.type );
            },
...
```

### Root Cause

This is because the parser is stopping at the first unescaped forward slash which is located in the character class. However a character class can contain unescaped forward slash ([see](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class#non-v-mode_character_class)) and is a valid regular expression in Javascript. 
Next it's parsing the rest of the regular expression as String starting from the string delimiter ` resulting in the next few lines not being minimized.

### Solution
Added logic to ignore unescaped forward slash inside a character class
### Issues
- Fixes #110
### Related Pull Requests
- https://github.com/tedious/JShrink/pull/124

### Comment
I understand there had been an attempt to fix this issue but was reverted later due to regression issues caused by the fix. As I understand the regression issues were found in Magento according to this [issue](https://github.com/tedious/JShrink/issues/135). I tested the solution with magento when JS minification is enabled and it worked fine.

```cli
 bin/magento config:set dev/js/minify_files 1
 bin/magento cache:flush
 bin/magento deploy:mode:set production
```

The same sequence of commands failed with the previously proposed [solution](https://github.com/tedious/JShrink/pull/124). 